### PR TITLE
added pre-configured petsc options

### DIFF
--- a/inputTemplates/petsc.options.asm
+++ b/inputTemplates/petsc.options.asm
@@ -1,0 +1,6 @@
+-rans2p_ksp_type bcgsl -rans2p_pc_type asm -rans2p_pc_asm_type basic -rans2p_sub_ksp_type preonly -rans2p_sub_pc_factor_mat_solver_package superlu
+-ncls_ksp_type   fgmres -ncls_pc_type   hypre -ncls_pc_hypre_type   boomeramg
+-vof_ksp_type    fgmres -vof_pc_type    hypre -vof_pc_hypre_type    boomeramg
+-rdls_ksp_type   fgmres -rdls_pc_type   hypre -vof_pc_hypre_type    boomeramg
+-mcorr_ksp_type  cg     -mcorr_pc_type  hypre -mcorr_pc_hypre_type  boomeramg
+-log_summary

--- a/inputTemplates/petsc.options.asm_fgmres
+++ b/inputTemplates/petsc.options.asm_fgmres
@@ -1,0 +1,10 @@
+-rans2p_ksp_type fgmres 
+-rans2p_ksp_gmres_restart 200 
+-rans2p_ksp_gmres_modifiedgramschmidt
+-rans2p_pc_type asm
+-rans2p_pc_asm_type basic
+-ncls_ksp_type   fgmres -ncls_pc_type   hypre -ncls_pc_hypre_type   boomeramg
+-vof_ksp_type    fgmres -vof_pc_type    hypre -vof_pc_hypre_type    boomeramg
+-rdls_ksp_type   fgmres -rdls_pc_type   hypre -vof_pc_hypre_type    boomeramg
+-mcorr_ksp_type  cg     -mcorr_pc_type  hypre -mcorr_pc_hypre_type  boomeramg
+-log_summary

--- a/inputTemplates/petsc.options.mumps
+++ b/inputTemplates/petsc.options.mumps
@@ -1,0 +1,5 @@
+-rans2p_ksp_type preonly -rans2p_pc_type lu -rans2p_pc_factor_mat_solver_package mumps
+-ncls_ksp_type   preonly -ncls_pc_type   lu -ncls_pc_factor_mat_solver_package   mumps
+-vof_ksp_type    preonly -vof_pc_type    lu -vof_pc_factor_mat_solver_package    mumps
+-rdls_ksp_type   preonly -rdls_pc_type   lu -rdls_pc_factor_mat_solver_package   mumps
+-mcorr_ksp_type  preonly -mcorr_pc_type  lu -mcorr_pc_factor_mat_solver_package  mumps

--- a/inputTemplates/petsc.options.superlu_dist
+++ b/inputTemplates/petsc.options.superlu_dist
@@ -1,0 +1,8 @@
+-rans2p_ksp_type preonly -rans2p_pc_type lu -rans2p_pc_factor_mat_solver_package superlu_dist
+-ncls_ksp_type   preonly -ncls_pc_type   lu -ncls_pc_factor_mat_solver_package   superlu_dist
+-vof_ksp_type    preonly -vof_pc_type    lu -vof_pc_factor_mat_solver_package    superlu_dist
+-rdls_ksp_type   preonly -rdls_pc_type   lu -rdls_pc_factor_mat_solver_package   superlu_dist
+-mcorr_ksp_type  preonly -mcorr_pc_type  lu -mcorr_pc_factor_mat_solver_package  superlu_dist
+-kappa_ksp_type preonly -kappa_pc_type lu -kappa_pc_factor_mat_solver_package superlu_dist
+-dissipation_ksp_type preonly -dissipation_pc_type lu -dissipation_pc_factor_mat_solver_package superlu_dist
+


### PR DESCRIPTION
Use these with the -O options to parun:

```
parun dambreak_so.py -O ../../inputTemplates/petsc.options.asm_fgmres
```
