### PR TITLE
Adds batch file for printing eddy viscosity, cleans up undefined keyword argument for ```movingDomain```

### DIFF
--- a/2d/dambreak_Colagrossi/dambreak_Colagrossi_coarse/eddy_viscosity_view_batch.py
+++ b/2d/dambreak_Colagrossi/dambreak_Colagrossi_coarse/eddy_viscosity_view_batch.py
@@ -1,0 +1,6 @@
+#0 is Navier-Stokes flow model
+simFlagsList[0]['storeQuantities']= ['simulationData',"q:'eddy_viscosity'"]
+simFlagsList[0]['storeTimes']     = ['All']
+#
+start
+quit

--- a/2d/dambreak_Colagrossi/dambreak_Colagrossi_coarse/ls_p.py
+++ b/2d/dambreak_Colagrossi/dambreak_Colagrossi_coarse/ls_p.py
@@ -7,7 +7,7 @@ LevelModelType = NCLS.LevelModel
 
 coefficients = NCLS.Coefficients(V_model=0,RD_model=3,ME_model=2,
                                  checkMass=False, useMetrics=useMetrics,
-                                 epsFact=epsFact_consrv_heaviside,sc_uref=ls_sc_uref,sc_beta=ls_sc_beta,movingDomain=movingDomain)
+                                 epsFact=epsFact_consrv_heaviside,sc_uref=ls_sc_uref,sc_beta=ls_sc_beta)
  
 def getDBC_ls(x,flag):
     return None

--- a/2d/dambreak_Colagrossi/dambreak_Colagrossi_coarse/vof_p.py
+++ b/2d/dambreak_Colagrossi/dambreak_Colagrossi_coarse/vof_p.py
@@ -14,7 +14,7 @@ else:
 
 coefficients = VOF.Coefficients(LS_model=LS_model,V_model=0,RD_model=RD_model,ME_model=1,
                                 checkMass=False,useMetrics=useMetrics,
-                                epsFact=epsFact_vof,sc_uref=vof_sc_uref,sc_beta=vof_sc_beta,movingDomain=movingDomain)
+                                epsFact=epsFact_vof,sc_uref=vof_sc_uref,sc_beta=vof_sc_beta)
 
 def getDBC_vof(x,flag):
    if flag == boundaryTags['top']:# or x[1] >= L[1] - 1.0e-12:

--- a/3d/dambreak/ls_p.py
+++ b/3d/dambreak/ls_p.py
@@ -7,7 +7,7 @@ LevelModelType = NCLS.LevelModel
 
 coefficients = NCLS.Coefficients(V_model=0,RD_model=3,ME_model=2,
                                  checkMass=False, useMetrics=useMetrics,
-                                 epsFact=epsFact_consrv_heaviside,sc_uref=ls_sc_uref,sc_beta=ls_sc_beta,movingDomain=movingDomain)
+                                 epsFact=epsFact_consrv_heaviside,sc_uref=ls_sc_uref,sc_beta=ls_sc_beta)
  
 def getDBC_ls(x,flag):
     return None

--- a/3d/dambreak/vof_p.py
+++ b/3d/dambreak/vof_p.py
@@ -14,7 +14,7 @@ else:
 
 coefficients = VOF.Coefficients(LS_model=LS_model,V_model=0,RD_model=RD_model,ME_model=1,
                                 checkMass=False,useMetrics=useMetrics,
-                                epsFact=epsFact_vof,sc_uref=vof_sc_uref,sc_beta=vof_sc_beta,movingDomain=movingDomain)
+                                epsFact=epsFact_vof,sc_uref=vof_sc_uref,sc_beta=vof_sc_beta)
 
 def getDBC_vof(x,flag):
     if flag == boundaryTags['top']:# or x[2] >= L[2] - 1.0e-12:


### PR DESCRIPTION
Requires pull request "add eddy viscosity" output from proteus-mprans to actually do anything. Running with the batch files and without the proteus-mprans pull request would cause an error.
